### PR TITLE
Added custom scroll bar, and scrollable record section on machine page

### DIFF
--- a/src/app/pages/machines/machine-detail-page/machine-detail-page.component.html
+++ b/src/app/pages/machines/machine-detail-page/machine-detail-page.component.html
@@ -1,10 +1,10 @@
-<div class="flex md:flex-row flex-col w-full justify-stretch p-2 h-full">
+<div class="flex md:flex-row flex-col w-full justify-stretch p-2 pt-0">
   <!-- Location detail section -->
-  <section class="md:w-1/2 w-full flex flex-col items-start pb-4 border-0 border-b-2 md:border-r-2">
+  <section class="md:w-1/2 w-full flex flex-col items-start pb-4 border-0 max-md:border-b-2 md:border-r-2 h-3/5">
     <mach:alert class="w-full m-2" />
     <div class="w-full pr-2">
       <div
-        class="mt-6 mr-2 p-4 pe-2 bg-gray-100 border-l-4 border-[#093d82] rounded-lg w-full flex justify-between items-center">
+        class="mr-2 p-4 pe-2 bg-gray-100 border-l-4 border-[#093d82] rounded-lg w-full flex justify-between items-center">
         <p class="text-xl font-extrabold text-black">{{locationDetail.name}}</p>
         <a [routerLink]="['/locations', locationDetail.id]" class="no-underline">
           <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
@@ -31,8 +31,8 @@
       </div>
     </form>
   </section>
-  <div class="w-10 h-full relative flex flex-col items-start justify-start">
-    <div class="absolute left-4 md:rotate-90 top-5 transform flex origin-left items-center">
+  <div class="w-10 h-full relative flex flex-col items-start justify-start max-md:h-5">
+    <div class="absolute left-4 max-md:left-4 md:rotate-90 top-5 max-md:top-0 transform flex origin-left items-center">
       <!-- Rotated Button 1 -->
       <button (click)="viewRecordSection = true" [class]="viewRecordSection ? 'bg-gray-200' : 'bg-gray-100'" class="w-24 text-black pt-2 px-2 mr-2 rounded-md rounded-b-none shadow-md">
         Záznamy
@@ -52,19 +52,21 @@
         <h2 class="pt-6 text-lg font-bold text-start text-black">Záznamy</h2>
         <button (click)="newRecord()" class="btn btn-primary mt-4">Přidat záznam</button>
       </div>
-      @for (record of records; track record.id) {
-      <div class="mt-6 p-4 bg-gray-100 border-l-4 border-[#093d82] rounded-lg w-full flex justify-between items-center">
-        <p class="text-xl font-extrabold text-black">{{record.date}}</p>
-        <p class="text-xl font-light text-black">{{record.type}}</p>
-        <a [routerLink]="['/records', record.id]" class="no-underline">
-          <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
-            width="24" height="24" fill="none" viewBox="0 0 24 24">
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778" />
-          </svg>
-        </a>
+      <div class="custom-scrollbar overflow-y-auto h-3/5">
+        @for (record of records; track record.id) {
+          <div class="mt-6 p-4 bg-gray-100 border-l-4 border-[#093d82] rounded-lg w-full flex justify-between items-center">
+            <p class="text-xl font-extrabold text-black">{{record.date}}</p>
+            <p class="text-xl font-light text-black">{{record.type}}</p>
+            <a [routerLink]="['/records', record.id]" class="no-underline">
+              <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                width="24" height="24" fill="none" viewBox="0 0 24 24">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778" />
+              </svg>
+            </a>
+          </div>
+          }
       </div>
-      }
     </div>
     }@else{
     <div>

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
-<body class="flex flex-col min-h-screen ">
+<body class="flex flex-col min-h-screen custom-scrollbar overflow-y-auto h-64">
   <app-root class="min-h-screen"></app-root>
 </body>
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -113,3 +113,23 @@ a {
 .list-item{
   @apply list-none w-2/3 p-2 m-2  text-[#1F0F53] rounded-xl bg-white shadow-md;
 }
+
+/* Customize scrollbar for Chrome, Edge, Safari */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px; /* Width of scrollbar */
+  @apply py-6 ;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #f1f1f1; /* Track color */
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #888; /* Scrollbar color */
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #555; /* Darker on hover */
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,4 +10,7 @@ module.exports = {
   plugins: [
     require('flowbite/plugin')
   ],
+  corePlugins: {
+    scrollbar: false,
+  },
 }


### PR DESCRIPTION
This pull request focuses on improving the user interface and user experience by refining the layout and adding custom scrollbar styling.

### Layout Improvements:

* [`src/app/pages/machines/machine-detail-page/machine-detail-page.component.html`](diffhunk://#diff-0728acfa6f244067354185bab2969392a21801b3f70dbd0ac50fb261bdd1ec1dL1-R7): Adjusted the layout of the machine detail page to improve responsiveness and visual hierarchy. Notable changes include modifying the `div` and `section` elements to better utilize space and adding a custom scrollbar to the records section. [[1]](diffhunk://#diff-0728acfa6f244067354185bab2969392a21801b3f70dbd0ac50fb261bdd1ec1dL1-R7) [[2]](diffhunk://#diff-0728acfa6f244067354185bab2969392a21801b3f70dbd0ac50fb261bdd1ec1dL34-R35) [[3]](diffhunk://#diff-0728acfa6f244067354185bab2969392a21801b3f70dbd0ac50fb261bdd1ec1dR55) [[4]](diffhunk://#diff-0728acfa6f244067354185bab2969392a21801b3f70dbd0ac50fb261bdd1ec1dR70)

### Custom Scrollbar Styling:

* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL17-R17): Added the `custom-scrollbar` class to the `body` element to apply custom scrollbar styling.
* [`src/styles.scss`](diffhunk://#diff-23fad3928bf3e71585eb4a6e3b2ff72dae02c3ed5a44d2f0deb1d49f0cb3b1a3R116-R135): Introduced new CSS rules to customize the appearance of scrollbars for Chrome, Edge, and Safari browsers. This includes setting the width, track color, and thumb color of the scrollbar, as well as adding hover effects.